### PR TITLE
OM-321: init landing, setup moldova landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ In development mode, you can use `yarn link` and `yarn start` to continuously sc
 
 ## Main Contribution
 
-__core.LandingPage__: This module serves as the Landing Page for the Moldova implementation. To enable its use, it must be exposed as a __core.LandingPage__ contribution point. Additionally, the database configuration variable __App.enableLandingPage__ must be set to **true**.
+**core.PublicPage**: This module serves as the Public Page for the Moldova implementation (Landing Page). To enable its use, it must be exposed as a **core.PublicPage** contribution point. Additionally, the database configuration variable **App.enablePublicPage** must be set to `true`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# openIMIS Frontend Template module
-This repository holds the files of the openIMIS Frontend Template module.
+# openIMIS Frontend Moldova Landing module
+
+This repository holds the files of the openIMIS Frontend Moldova Landing module.
 It is dedicated to be bootstrap development of [openimis-fe_js](https://github.com/openimis/openimis-fe_js) modules, providing an empty (yet deployable) module.
 
 Please refer to [openimis-fe_js](https://github.com/openimis/openimis-fe_js) to see how to build and and deploy (in developement or server mode).
@@ -9,4 +10,7 @@ In development mode, you can use `yarn link` and `yarn start` to continuously sc
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/openimis/openimis-fe-template_js.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/openimis/openimis-fe-template_js/alerts/)
-# openimis-fe-moldova_landing_js
+
+## Main Contribution
+
+__core.LandingPage__: This module serves as the Landing Page for the Moldova implementation. To enable its use, it must be exposed as a __core.LandingPage__ contribution point. Additionally, the database configuration variable __App.enableLandingPage__ must be set to **true**.

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,6 @@
+export const MODULE_NAME = 'moldovaLanding';
+
+export const ROUTES = {
+  LANDING: '/',
+  LOGIN: '/login',
+};

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import messages_en from './translations/en.json';
 
 const DEFAULT_CONFIG = {
   translations: [{ key: 'en', messages: messages_en }],
-  'core.LandingPage': LandingPage,
+  'core.PublicPage': LandingPage,
 };
 
 export const MoldovaLandingModule = (cfg) => ({ ...DEFAULT_CONFIG, ...cfg });

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,13 @@
+/* eslint-disable react/react-in-jsx-scope */
+/* eslint-disable import/prefer-default-export */
+/* eslint-disable camelcase */
+
+import LandingPage from './pages/LandingPage';
 import messages_en from './translations/en.json';
 
 const DEFAULT_CONFIG = {
   translations: [{ key: 'en', messages: messages_en }],
+  'core.LandingPage': LandingPage,
 };
 
-export const MoldovaLandingModule = (cfg) => {
-  return { ...DEFAULT_CONFIG, ...cfg };
-};
+export const MoldovaLandingModule = (cfg) => ({ ...DEFAULT_CONFIG, ...cfg });

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { Button } from '@material-ui/core';
+
+import {
+  Helmet,
+  useHistory,
+  useModulesManager,
+  useTranslations,
+} from '@openimis/fe-core';
+import { MODULE_NAME, ROUTES } from '../constants';
+
+function LandingPage() {
+  const modulesManager = useModulesManager();
+  const history = useHistory();
+  const { formatMessage } = useTranslations(MODULE_NAME, modulesManager);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'column',
+        height: '100vh',
+      }}
+    >
+      <Helmet title="Landing Page" />
+      <h1> There will be a Landing Page soon...</h1>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={() => history.push(ROUTES.LOGIN)}
+      >
+        {formatMessage('LoginButtonLabel')}
+      </Button>
+    </div>
+  );
+}
+
+export default LandingPage;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,2 +1,3 @@
 {
+  "moldovaLanding.LoginButtonLabel": "Login"
 }


### PR DESCRIPTION
[OM-321](https://openimis.atlassian.net/browse/OM-321)

Changes:
- If `App.enableLandingPage` set to true and user is not authenticated, the Landing Page would be available for users at `/front` path.

[OM-321]: https://openimis.atlassian.net/browse/OM-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ